### PR TITLE
Fix 404 for latest 1.4.x-stable release signature

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ What's new in: <a href="https://raw.github.com/libevent/libevent/patches-2.0/wha
        <li>and more...
       </ul>
 
-	<li><a href="https://github.com/libevent/libevent/archive/release-1.4.15-stable.tar.gz">libevent-1.4.15-stable.tar.gz</a> [<a href="https://github.com/downloads/libevent/libevent/libevent-1.4.15-stable.tar.gz.sig">GPG Sig</a>] <a href="https://raw.github.com/libevent/libevent/release-1.4.15-stable/ChangeLog">ChangeLog</a><br>Released 2015-01-05
+	<li><a href="https://github.com/libevent/libevent/archive/release-1.4.15-stable.tar.gz">libevent-1.4.15-stable.tar.gz</a> <a href="https://raw.github.com/libevent/libevent/release-1.4.15-stable/ChangeLog">ChangeLog</a><br>Released 2015-01-05
           <ul>
             <li>Changelog to follow
            </ul>


### PR DESCRIPTION
Assuming the tag was applied to the right SHA1 then it could be used to verify the contents of this package and therefore a signature might be irrelevant.

There is hope that if a new release is done for this branch, it will use the same procedure applied to the other 2 stable branches and as indicated in nmathewson/Libevent#151